### PR TITLE
ProgressBar update

### DIFF
--- a/src/M5StackUpdater.h
+++ b/src/M5StackUpdater.h
@@ -73,15 +73,16 @@ void displayUpdateUI(String fileName) {
   M5.Lcd.setTextColor(WHITE);
   M5.Lcd.setTextSize(2);
   M5.Lcd.printf(String("LOADING " + fileName).c_str());
-  M5.Lcd.drawRect(110, 130, 100, 20, WHITE);
-  M5.Lcd.drawRect(111, 131, 98, 18, BLACK);
+  M5.Lcd.drawRect(110, 130, 102, 20, WHITE);
 }
 
 
-void progress(int state, int size){
+void progress(int state, int size) {
   int percent = (state*100) / size;
   Serial.printf("percent = %d", percent);
-  M5.Lcd.drawRect(111, 131, percent, 18, GREEN);
+  if (percent > 0) {
+    M5.Lcd.drawRect(111, 131, percent, 18, GREEN);
+  }
 }
 
 // perform the actual update from a given stream


### PR DESCRIPTION
1.
**void displayUpdateUI** remove line:
```
M5.Lcd.drawRect(111, 131, 98, 18, BLACK);
```
not needed (for me) because interior of the white rectangle are cleaned by M5.Lcd.fillScreen(BLACK)

2.
**void displayUpdateUI** -> increasing width of the white progress frame border from 100 to 102, to make the black interior size equal 100  (102 - 1[left frame border] - 1[right frame border] = 100[for percent 1..100]),
it prevents overwriting right side of white progress frame with green progress (when percent values = 99 or 100)
```
M5.Lcd.drawRect(110, 130, 102, 20, WHITE);
```

3.
**void progress**:
do not drawRect when percent==0, because this overwrite left side of white progress frame
look at M5Stack->Display.cpp->void ILI9341::drawRect line 768:
drawFastVLine(x + w - 1, y, h, color);