### PR TITLE
harmonizing qrCode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - unzip -d ~/Arduino/libraries M5StackSAM-master.zip
   - wget https://github.com/ricmoo/QRCode/archive/master.zip --output-document=QRCode-master.zip
   - unzip -d ~/Arduino/libraries QRCode-master.zip
-  - wget https://github.com/m5stack/M5Stack/archive/0.1.6.zip --output-document=M5Stack.zip
+  - wget https://github.com/m5stack/M5Stack/archive/master.zip --output-document=M5Stack.zip
   - unzip -d ~/Arduino/libraries M5Stack.zip
   
 script:

--- a/examples/M5Stack-SD-Menu/M5Stack-SD-Menu.ino
+++ b/examples/M5Stack-SD-Menu/M5Stack-SD-Menu.ino
@@ -65,13 +65,14 @@
  */
  
 #include "SPIFFS.h"
-#include "qrcode.h"            // https://github.com/ricmoo/qrcode
 #include <M5Stack.h>             // https://github.com/m5stack/M5Stack/
+#include "utility/qrcode.h"      // qrCode from M5Stack
 #include "M5StackUpdater.h"      // https://github.com/tobozo/M5Stack-SD-Updater
 #include <M5StackSAM.h>          // https://github.com/tomsuch/M5StackSAM
 #include <ArduinoJson.h>         // https://github.com/bblanchon/ArduinoJson/
 #include "i18n.h"                // language file
 #include "assets.h"              // some artwork for the UI
+
 
 
 

--- a/examples/M5Stack-SD-Menu/M5Stack-SD-Menu.ino
+++ b/examples/M5Stack-SD-Menu/M5Stack-SD-Menu.ino
@@ -65,13 +65,11 @@
  */
  
 #include "SPIFFS.h"
+#include "qrcode.h"            // https://github.com/ricmoo/qrcode
 #include <M5Stack.h>             // https://github.com/m5stack/M5Stack/
 #include "M5StackUpdater.h"      // https://github.com/tobozo/M5Stack-SD-Updater
 #include <M5StackSAM.h>          // https://github.com/tomsuch/M5StackSAM
 #include <ArduinoJson.h>         // https://github.com/bblanchon/ArduinoJson/
-#ifndef __QRCODE_H_              // upcoming changes on the M5Stack library
-  #include "qrcode.h"            // https://github.com/ricmoo/qrcode
-#endif
 #include "i18n.h"                // language file
 #include "assets.h"              // some artwork for the UI
 

--- a/examples/M5Stack-SD-Menu/M5Stack-SD-Menu.ino
+++ b/examples/M5Stack-SD-Menu/M5Stack-SD-Menu.ino
@@ -69,7 +69,9 @@
 #include "M5StackUpdater.h"      // https://github.com/tobozo/M5Stack-SD-Updater
 #include <M5StackSAM.h>          // https://github.com/tomsuch/M5StackSAM
 #include <ArduinoJson.h>         // https://github.com/bblanchon/ArduinoJson/
-#include "qrcode.h"              // https://github.com/ricmoo/qrcode
+#ifndef __QRCODE_H_              // upcoming changes on the M5Stack library
+  #include "qrcode.h"            // https://github.com/ricmoo/qrcode
+#endif
 #include "i18n.h"                // language file
 #include "assets.h"              // some artwork for the UI
 


### PR DESCRIPTION
M5Stack updated their repo with the latest qrcode library, this broke travis and will probably break any upcoming installation, preparing for next release.