### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Package your apps on an SD card and load them from a menu app, button 
 category=Uncategorized
 url=https://github.com/tobozo/M5Stack-SD-Updater/
 architectures=esp32 
+depends=M5Stack


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: I did not add ArduinoJson and M5StackSAM as dependencies because these are only dependencies of the example sketches, not the library itself. However, I also think it would be a reasonable decision to install dependencies of the examples as well. If you would prefer these libraries be added as dependencies, I'm happy to update this PR accordingly.