### PR TITLE
Update downloader.h

### DIFF
--- a/examples/M5Stack-SD-Menu/downloader.h
+++ b/examples/M5Stack-SD-Menu/downloader.h
@@ -736,7 +736,7 @@ bool syncConnect(WiFiClientSecure *client, HTTPRouter &router, URLParts urlParts
   } else {
     log_d(" [%s:INFO] An HTTP (NO TLS) URL was called (%s)", sender, urlParts.url.c_str() );
     router.endhttp = false;
-    http.begin( urlParts.url );
+    http.begin(*client, urlParts.url );
   }
   log_d( "[%s:INFO] Running http.GET( %s ) [%d]", sender, urlParts.url.c_str(), ESP.getFreeHeap() );
   int httpCode = http.GET();


### PR DESCRIPTION
esp32/1.0.4 の場合に http.begin(urlParts.url )でクラッシュする問題
https://github.com/espressif/arduino-esp32/issues/3347